### PR TITLE
[ISSUE-18] t-progress component

### DIFF
--- a/src/app/components/t-progress/t-progress.component.html
+++ b/src/app/components/t-progress/t-progress.component.html
@@ -1,0 +1,43 @@
+<svg
+  *ngIf="
+    radius >= MINIMUM_RADIUS &&
+    progress >= MINIMUM_PROGRESS &&
+    progress <= MAXIMUM_PROGRESS
+  "
+  attr.height="{{ (radius + margin) * 2 }}px"
+  attr.width="{{ (radius + margin) * 2 }}px"
+  attr.viewBox="0 0 {{ (radius + margin) * 2 }} {{ (radius + margin) * 2 }}"
+>
+  <div *ngIf="progress < 100; then thenBlock; else elseBlock"></div>
+  <ng-template #thenBlock>
+    <path
+      fill="none"
+      attr.stroke="{{ color }}"
+      attr.stroke-width="{{ 0.1 * radius }}"
+      stroke-linecap="round"
+      attr.d="{{ getPathString() }}"
+    />
+  </ng-template>
+  <ng-template #elseBlock>
+    <circle
+      fill="none"
+      attr.stroke="{{ color }}"
+      attr.stroke-width="{{ 0.1 * radius }}"
+      attr.cx="{{ radius + margin }}"
+      attr.cy="{{ radius + margin }}"
+      attr.r="{{ radius }}"
+    />
+  </ng-template>
+
+  <text
+    [ngStyle]="{
+      'font-size': 0.7 * radius,
+      fill: color,
+      stroke: color
+    }"
+    attr.x="{{ radius + margin }}"
+    attr.y="{{ radius + margin }}"
+  >
+    {{ progress }}%
+  </text>
+</svg>

--- a/src/app/components/t-progress/t-progress.component.scss
+++ b/src/app/components/t-progress/t-progress.component.scss
@@ -1,0 +1,7 @@
+svg {
+  text {
+    font-family: sans-serif;
+    text-anchor: middle;
+    dominant-baseline: middle;
+  }
+}

--- a/src/app/components/t-progress/t-progress.component.spec.ts
+++ b/src/app/components/t-progress/t-progress.component.spec.ts
@@ -1,0 +1,98 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import {
+  PROGRESS_ERROR_MESSAGE,
+  RADIUS_ERROR_MESSAGE,
+  TProgressComponent,
+} from './t-progress.component';
+
+describe('TProgressComponent', () => {
+  let component: TProgressComponent;
+  let fixture: ComponentFixture<TProgressComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TProgressComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TProgressComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should throw radius error', () => {
+    try {
+      component.ngOnChanges({
+        radius: {
+          firstChange: true,
+          isFirstChange: () => true,
+          previousValue: undefined,
+          currentValue: 20,
+        },
+        progress: {
+          firstChange: true,
+          isFirstChange: () => true,
+          previousValue: undefined,
+          currentValue: 20,
+        },
+      });
+    } catch (e) {
+      expect((e as Error).message).toBe(RADIUS_ERROR_MESSAGE);
+    }
+  });
+
+  it('should throw progress error on negative values', () => {
+    try {
+      component.ngOnChanges({
+        radius: {
+          firstChange: true,
+          isFirstChange: () => true,
+          previousValue: undefined,
+          currentValue: 60,
+        },
+        progress: {
+          firstChange: true,
+          isFirstChange: () => true,
+          previousValue: undefined,
+          currentValue: -20,
+        },
+      });
+    } catch (e) {
+      expect((e as Error).message).toBe(PROGRESS_ERROR_MESSAGE);
+    }
+  });
+
+  it('should throw progress error on values over 100', () => {
+    try {
+      component.ngOnChanges({
+        radius: {
+          firstChange: true,
+          isFirstChange: () => true,
+          previousValue: undefined,
+          currentValue: 60,
+        },
+        progress: {
+          firstChange: true,
+          isFirstChange: () => true,
+          previousValue: undefined,
+          currentValue: 120,
+        },
+      });
+    } catch (e) {
+      expect((e as Error).message).toBe(PROGRESS_ERROR_MESSAGE);
+    }
+  });
+
+  it('should return correct path string', () => {
+    component.radius = 100;
+    component.progress = 50;
+    fixture.detectChanges();
+    component.ngOnInit();
+    const pathString = component.getPathString();
+    expect(pathString).toBe('M 110, 10 A 100, 100, 0 1 1 110, 210');
+  });
+});

--- a/src/app/components/t-progress/t-progress.component.ts
+++ b/src/app/components/t-progress/t-progress.component.ts
@@ -1,0 +1,92 @@
+import { CommonModule } from '@angular/common';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  NO_ERRORS_SCHEMA,
+  Output,
+  SimpleChanges,
+} from '@angular/core';
+
+type Point = {
+  x: number;
+  y: number;
+};
+
+export const RADIUS_ERROR_MESSAGE = 't-progress radius value is less than 50';
+export const PROGRESS_ERROR_MESSAGE =
+  't-progress progress value is outside of the [0, 100] interval';
+
+@Component({
+  selector: 't-progress',
+  standalone: true,
+  imports: [CommonModule],
+  schemas: [NO_ERRORS_SCHEMA],
+  templateUrl: './t-progress.component.html',
+  styleUrl: './t-progress.component.scss',
+})
+export class TProgressComponent {
+  @Input() radius: number;
+  @Input() progress: number;
+  @Input() color: string;
+  @Output() complete = new EventEmitter<void>();
+
+  // A safety margin proportional to the radius so that the circle stroke does not overflow outside the svg element.
+  margin: number;
+  public readonly MINIMUM_RADIUS: number = 50;
+  public readonly MINIMUM_PROGRESS: number = 0;
+  public readonly MAXIMUM_PROGRESS: number = 100;
+
+  //IMPORTANT NOTE: while running in storybook, the errors will be thrown twice (does not reproduce while running with `ng serve`)
+  ngOnChanges(simpleChanges: SimpleChanges) {
+    if (simpleChanges['radius'].currentValue < this.MINIMUM_RADIUS) {
+      throw new Error(RADIUS_ERROR_MESSAGE);
+    }
+
+    if (
+      simpleChanges['progress'].currentValue < this.MINIMUM_PROGRESS ||
+      simpleChanges['progress'].currentValue > this.MAXIMUM_PROGRESS
+    ) {
+      throw new Error(PROGRESS_ERROR_MESSAGE);
+    }
+  }
+
+  ngOnInit() {
+    this.margin = 0.1 * this.radius;
+  }
+
+  ngAfterViewInit() {
+    if (this.progress === this.MAXIMUM_PROGRESS) {
+      this.complete.emit();
+    }
+  }
+
+  getPathString() {
+    const centerPoint: Point = {
+      x: this.radius + this.margin,
+      y: this.radius + this.margin,
+    };
+
+    // Point at the top of the circle.
+    const startPoint: Point = {
+      x: this.radius + this.margin,
+      y: this.margin,
+    };
+
+    // The angle describing the circle arc - directly proportional to the progress.
+    const arcAngle = (2 * Math.PI * this.progress) / 100;
+
+    // Angle measured against the Ox axis.
+    const referenceAngle = Math.PI / 2 - arcAngle;
+
+    // End point of circle arc.
+    const endPoint: Point = {
+      x: centerPoint.x + this.radius * Math.cos(referenceAngle),
+      y: centerPoint.y - this.radius * Math.sin(referenceAngle),
+    };
+
+    const largeArcFlag = this.progress >= 50 ? 1 : 0;
+
+    return `M ${startPoint.x}, ${startPoint.y} A ${this.radius}, ${this.radius}, 0 ${largeArcFlag} 1 ${endPoint.x}, ${endPoint.y}`;
+  }
+}

--- a/src/stories/t-grid/t-grid.stories.ts
+++ b/src/stories/t-grid/t-grid.stories.ts
@@ -45,9 +45,7 @@ const meta: Meta<TGridComponent<MockUser>> = {
 };
 
 export default meta;
-type Story = StoryObj<
-  TGridComponent<MockUser> & { x: (e: SortChangeEvent) => void }
->;
+type Story = StoryObj<TGridComponent<MockUser>>;
 
 export const SortableGrid: Story = {
   args: {

--- a/src/stories/t-progress/t-progress.stories.ts
+++ b/src/stories/t-progress/t-progress.stories.ts
@@ -1,0 +1,87 @@
+import { StoryObj, moduleMetadata, type Meta } from '@storybook/angular';
+import { CommonModule } from '@angular/common';
+import { TProgressComponent } from '../../app/components/t-progress/t-progress.component';
+
+const meta: Meta<TProgressComponent> = {
+  title: 'Assignment/t-progress',
+  component: TProgressComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [CommonModule],
+    }),
+  ],
+  render: (args) => ({
+    props: {
+      ...args,
+      logEvent: () => console.log('t-progress completed!'),
+    },
+    template: `
+      <t-progress 
+        [radius]="radius" 
+        [progress]="progress" 
+        [color]="color"
+        (complete)="logEvent()"
+      >
+      </t-progress>
+    `,
+  }),
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<TProgressComponent>;
+export const Default: Story = {
+  args: {
+    radius: 70,
+    color: 'green',
+    progress: 50,
+  },
+};
+
+export const SmallRadius: Story = {
+  args: {
+    radius: 50,
+    color: 'blue',
+    progress: 25,
+  },
+};
+
+export const BigRadius: Story = {
+  args: {
+    radius: 200,
+    color: 'purple',
+    progress: 63,
+  },
+};
+
+export const FullProgress: Story = {
+  args: {
+    radius: 75,
+    color: 'darkgreen',
+    progress: 100,
+  },
+};
+
+export const SmallProgress: Story = {
+  args: {
+    radius: 75,
+    color: 'red',
+    progress: 2,
+  },
+};
+
+export const RadiusError: Story = {
+  args: {
+    radius: 30,
+    color: 'blue',
+    progress: 70,
+  },
+};
+
+export const ProgressError: Story = {
+  args: {
+    radius: 70,
+    color: 'blue',
+    progress: 120,
+  },
+};


### PR DESCRIPTION
# Issue link
#18 
# Description
Implementation of the `t-progress` component.
It uses `path` element within an `svg` when the `progress` input is not `100`.
For the case where `progress` is `100`, we use a `circle` instead.
It uses a bit of trigonometry to calculate the position of the points.
# How to test?

1. open the storybook
2. change the parameters in the storybook to match different values
3. ensure the radius, color and progress change
4. insert some invalid values for the radius and/or progress and check the console for errors (when running in the storybook, they will be thrown twice). For invalid values, nothing will be rendered on the screen
5. modify the progress to be `100` and check in the console for a emitted event.

# Attachments
![image](https://github.com/raresGabriel01/home-assignment/assets/56756497/26a71649-4002-4c7f-981e-e3f7bc177083)

![image](https://github.com/raresGabriel01/home-assignment/assets/56756497/405b09fb-d921-43fd-9a10-42158561c9fc)
